### PR TITLE
[FEAT] auth관련 기본 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### H2DB ###
+*.db

--- a/Agent/AGENTS.md
+++ b/Agent/AGENTS.md
@@ -1,0 +1,25 @@
+# Repository Guidelines
+## 프로젝트 구조 및 모듈 구성
+- `src/main/java/com/todate/backend`는 인증(auth), 사용자(user), 코스(course), 스팟(spot) 도메인을 중심으로 controller → service → domain/repository 계층을 유지한다. 새로운 모듈도 동일한 계층을 따라 패키지를 추가한다.
+- `src/main/resources`에는 공통 설정 `application.yml`과 로컬 전용 `application-local.yml`이 있으며, 정적 자원은 `static`, 템플릿은 `templates`에 둔다.
+- 테스트 코드는 `src/test/java` 아래에서 프로덕션 패키지를 거울처럼 복제하고, 공용 테스트 픽스처는 도메인별 하위 패키지에 모아 재사용성을 높인다.
+## 빌드, 테스트, 개발 커맨드
+- `./gradlew clean build` : 전체 빌드와 모든 단위 테스트를 실행해 CI와 동일한 결과를 확인한다.
+- `./gradlew test` : JUnit 기반 테스트만 실행한다. 실패 시 `--info` 옵션으로 로그를 확장해 원인을 파악한다.
+- `./gradlew bootRun --args='--spring.profiles.active=local'` : 로컬 서버를 8080 포트에서 기동하고 H2 메모리 DB 설정을 적용한다.
+## 코딩 스타일 및 네이밍 규칙
+- Java 21과 Spring Boot 3.5를 기준으로 하며, 클래스·패키지는 `PascalCase`, 메서드·변수는 `camelCase`를 사용한다.
+- 컨트롤러 엔드포인트는 REST 관례에 따라 복수형 URI와 명확한 HTTP 메서드를 사용한다.
+- Lombok을 사용할 때는 필수 인자가 드러나도록 `@Builder`, `@RequiredArgsConstructor`를 우선 적용하고, DTO에는 명시적 필드명을 유지한다.
+- 코드 포매팅은 4칸 들여쓰기와 공백 기반 정렬을 따른다. 변경이 크면 IDE 자동 정렬 후 `diff`를 검토한다.
+## 테스트 지침
+- 단위 테스트는 JUnit 5와 Spring Boot Test를 사용하며, 클래스명은 `클래스명Test` 패턴을 따른다.
+- 서비스 계층은 Mockito 혹은 `@DataJpaTest`로 외부 의존성을 격리하고, 컨트롤러는 `@WebMvcTest`로 슬라이스 테스트를 작성한다.
+- 새로운 기능은 성공·실패 케이스를 모두 포함한 최소 두 개 시나리오를 준비하고, `@DisplayName`으로 한글 설명을 명시한다.
+## 커밋 및 PR 가이드라인
+- 커밋 메시지는 `[TYPE] 요약` 형식을 사용한다. TYPE 예시는 `FEAT`, `FIX`, `REFACTOR`, `REMOVE`, `CHORE`이며, 본문에는 변경 이유와 영향 범위를 적는다.
+- PR은 변경 요약, 테스트 결과(`./gradlew test` 출력 요약), 연관 이슈 링크를 포함한다. API 스펙이 변하면 요청·응답 예시나 문서 링크를 함께 제공한다.
+- 리뷰 전 로컬에서 테스트를 통과시키고, 설정이나 문서가 변하면 `HELP.md` 또는 관련 가이드를 갱신했는지 확인한다.
+## 보안 및 설정 팁
+- 민감한 비밀키는 환경 변수나 외부 시크릿 관리 도구로 주입하고, `application-local.yml`에는 목업 값만 남긴다.
+- 데이터베이스 혹은 OAuth 자격 증명을 커밋하지 말고, 필요한 경우 샘플 값을 별도 공유 채널에 제공한다.

--- a/Agent/AUTH_PLAN.md
+++ b/Agent/AUTH_PLAN.md
@@ -1,0 +1,23 @@
+# Auth 구현 계획
+
+## 개요
+- `/auth/login` POST 요청으로 사용자 인증을 처리하고, Spring Security 최신 API에 맞춰 JWT 기반 세션리스 인증 흐름을 완성한다.
+- 모든 구현은 deprecated된 구성 요소를 회피하고, 기존 `/auth/register` 및 JWT 유틸과 자연스럽게 연동하도록 진행한다.
+
+## 현재 상태 검토
+- `AuthController`의 `AuthService` 필드가 `final`이 아니어서 DI가 적용되지 않으며, 로그인 엔드포인트가 주석 처리돼 있다.
+- `SignInRequest`, `AccessTokenResponse`, `AuthService.login`, `BasicAuthenticationProvider`, `BasicAuthenticationFilter`, `JwtAuthenticationFilter` 등이 미완성 상태다.
+- `SecurityConfig`에 JWT 필터 체인이 추가되지 않았고, `JwtProps`에 대한 `@EnableConfigurationProperties` 선언도 필요할 수 있다.
+
+## 구현 단계
+1. **DTO 및 응답 정비**: `SignInRequest`에 접근자/검증 애너테이션을 보완하고, `AccessTokenResponse`를 토큰·유효기간 등의 필드로 확장해 정적 팩터리로 생성한다.
+2. **AuthService.login 구현**: 사용자 조회 → 비밀번호 검증(`PasswordEncoder.matches`) → `JwtUtil.generateAccessToken`(필요 시 refresh) → DTO 반환. 인증 실패 시 `ResponseStatusException(HttpStatus.UNAUTHORIZED)` 활용.
+3. **인증 컴포넌트 보완**: `BasicAuthenticationProvider`에 `UserDetailsService`와 `PasswordEncoder`를 `final`로 주입하고, 인증 검증 후 `UsernamePasswordAuthenticationToken`을 반환. `BasicAuthenticationFilter`는 `/auth/login` 요청을 가로채 `AuthenticationManager`로 인증을 위임하고, 성공 시 토큰 응답을 작성하도록 OncePerRequestFilter 기반으로 재구성 고려.
+4. **JWT 필터 연결**: `JwtAuthenticationFilter`를 최신 방식으로 정리하고, `SecurityConfig`에 `http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)`를 추가해 모든 보호된 요청에서 토큰을 검증한다.
+5. **예외 및 응답 처리**: 인증 실패, 토큰 유효성 오류에 대해 일관된 JSON 응답을 반환하도록 `AuthenticationEntryPoint`와 `AccessDeniedHandler`를 점검한다.
+6. **테스트 작성**: `AuthService` 단위 테스트로 성공/실패 케이스를 검증하고, `JwtUtil` 만료/재발급 시나리오를 테스트한다. WebMvcTest로 `/auth/login` 통합 흐름을 검증한다.
+7. **문서 업데이트**: `AGENTS.md`에 로그인 플로우, JWT 발급 방식, Postman 예제 등을 추가해 팀 내 공유를 완성한다.
+
+## 추가 고려 사항
+- H2/로컬 프로필에서의 비밀번호 해시 저장 여부와 REST 응답 포맷(응답 래퍼, 에러 코드)을 기존 컨벤션과 맞춘다.
+- Refresh 토큰 저장 전략과 재발급 엔드포인트는 후속 작업 범위로 남겨두되, `JwtUtil` 인터페이스가 확장 가능하도록 유지한다.

--- a/build.gradle
+++ b/build.gradle
@@ -26,13 +26,20 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     compileOnly 'org.projectlombok:lombok'
+
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.postgresql:postgresql'
+
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
 
+    // auth
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.7'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.7'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.7'
+
     compileOnly 'org.projectlombok:lombok'
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
 
     compileOnly 'org.projectlombok:lombok'
 

--- a/src/main/java/com/todate/backend/BackendApplication.java
+++ b/src/main/java/com/todate/backend/BackendApplication.java
@@ -1,9 +1,12 @@
 package com.todate.backend;
 
+import com.todate.backend.auth.jwt.JwtProps;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties(JwtProps.class)
 public class BackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/todate/backend/auth/config/SecurityConfig.java
+++ b/src/main/java/com/todate/backend/auth/config/SecurityConfig.java
@@ -1,0 +1,61 @@
+package com.todate.backend.auth.config;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final Environment env;
+
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((req, res, e) -> {
+                            res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                            res.setContentType("application/json");
+                            res.getWriter().write("{\"message\":\"Unauthorized\"}");
+                        })
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/auth/**", "/h2-console/**").permitAll()
+                        .anyRequest().authenticated()
+                );
+
+
+        if (env.acceptsProfiles(Profiles.of("local"))) {
+            http.headers(h -> h.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin));
+            http.authorizeHttpRequests(a -> a.requestMatchers("/h2-console/**").permitAll());
+        } else {
+            http.headers(h -> {
+                h.frameOptions(HeadersConfigurer.FrameOptionsConfig::deny);
+                h.contentSecurityPolicy(c -> c.policyDirectives("frame-ancestors 'none'"));
+            });
+        }
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/todate/backend/auth/config/SecurityConfig.java
+++ b/src/main/java/com/todate/backend/auth/config/SecurityConfig.java
@@ -1,11 +1,17 @@
 package com.todate.backend.auth.config;
 
+import com.todate.backend.auth.core.BasicAuthenticationProvider;
+import com.todate.backend.auth.jwt.JwtAuthenticationFilter;
+import com.todate.backend.auth.jwt.JwtProps;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.Profiles;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -14,44 +20,69 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@EnableConfigurationProperties(JwtProps.class)
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final Environment env;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
-    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http
-                .csrf(AbstractHttpConfigurer::disable)
-                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .formLogin(AbstractHttpConfigurer::disable)
-                .httpBasic(AbstractHttpConfigurer::disable)
-                .exceptionHandling(ex -> ex
-                        .authenticationEntryPoint((req, res, e) -> {
-                            res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                            res.setContentType("application/json");
-                            res.getWriter().write("{\"message\":\"Unauthorized\"}");
-                        })
-                )
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/**", "/h2-console/**").permitAll()
-                        .anyRequest().authenticated()
-                );
-
-
+    SecurityFilterChain securityFilterChain(HttpSecurity http, BasicAuthenticationProvider basicAuthenticationProvider) throws Exception {
         if (env.acceptsProfiles(Profiles.of("local"))) {
+            // local h2-console 인증 제외 및 iframe 허용
             http.headers(h -> h.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin));
             http.authorizeHttpRequests(a -> a.requestMatchers("/h2-console/**").permitAll());
         } else {
+            // 이외 경우 iframe deny
             http.headers(h -> {
                 h.frameOptions(HeadersConfigurer.FrameOptionsConfig::deny);
                 h.contentSecurityPolicy(c -> c.policyDirectives("frame-ancestors 'none'"));
             });
         }
 
+        http
+                // jwt 사용하므로 csrf 토큰 필요없음
+                .csrf(AbstractHttpConfigurer::disable)
+                // 내장 서버 세션 필요 없음
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                // 기본 로그인 폼 필요 없음
+                .formLogin(AbstractHttpConfigurer::disable)
+                // Basic 인증 끄기
+                .httpBasic(AbstractHttpConfigurer::disable)
+                // 요청 endpoint 별 인증 설정
+                .authorizeHttpRequests(auth -> auth
+                        // 인증 제외할 endpoint 명시
+                        .requestMatchers("/auth/**").permitAll()
+                        // 이외 request는 모두 인증
+                        .anyRequest().authenticated()
+                )
+                .authenticationProvider(basicAuthenticationProvider)
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                // 에러 핸들링
+                .exceptionHandling(ex -> ex
+                        // 인증 실패 401
+                        .authenticationEntryPoint((req, res, e) -> {
+                            res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                            res.setContentType("application/json");
+                            res.getWriter().write("{\"message\":\"Unauthorized\"}");
+                        })
+//                        // 인가 실패 403 (아직 필요 없음)
+//                        .accessDeniedHandler((req, res, e) -> {
+//                            res.setStatus(HttpServletResponse.SC_FORBIDDEN); // 403
+//                            res.setContentType("application/json");
+//                            res.getWriter().write("{\"message\":\"Forbidden\"}");
+//                        })
+                );
         return http.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(BasicAuthenticationProvider basicAuthenticationProvider) {
+        return new ProviderManager(basicAuthenticationProvider);
     }
 
     @Bean

--- a/src/main/java/com/todate/backend/auth/controller/AuthController.java
+++ b/src/main/java/com/todate/backend/auth/controller/AuthController.java
@@ -1,5 +1,24 @@
 package com.todate.backend.auth.controller;
 
-public class AuthController {
+import com.todate.backend.auth.dto.request.SignUpRequest;
+import com.todate.backend.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+    AuthService authService;
+
+    @PostMapping("signup")
+    public ResponseEntity<Void> signup(@RequestBody SignUpRequest signUpRequest){
+        authService.signupUser(signUpRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
 }

--- a/src/main/java/com/todate/backend/auth/controller/AuthController.java
+++ b/src/main/java/com/todate/backend/auth/controller/AuthController.java
@@ -1,7 +1,10 @@
 package com.todate.backend.auth.controller;
 
+import com.todate.backend.auth.dto.request.SignInRequest;
 import com.todate.backend.auth.dto.request.SignUpRequest;
+import com.todate.backend.auth.dto.response.AccessTokenResponse;
 import com.todate.backend.auth.service.AuthService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,11 +17,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/auth")
 public class AuthController {
-    AuthService authService;
+    private final AuthService authService;
 
-    @PostMapping("signup")
-    public ResponseEntity<Void> signup(@RequestBody SignUpRequest signUpRequest){
+    @PostMapping("/register")
+    public ResponseEntity<Void> signUp(@Valid @RequestBody SignUpRequest signUpRequest){
         authService.signupUser(signUpRequest);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<AccessTokenResponse> signIn(@Valid @RequestBody SignInRequest signInRequest){
+        AccessTokenResponse accessTokenResponse = authService.login(signInRequest);
+        return ResponseEntity.ok(accessTokenResponse);
     }
 }

--- a/src/main/java/com/todate/backend/auth/core/BasicAuthenticationProvider.java
+++ b/src/main/java/com/todate/backend/auth/core/BasicAuthenticationProvider.java
@@ -1,0 +1,41 @@
+package com.todate.backend.auth.core;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BasicAuthenticationProvider implements AuthenticationProvider {
+    private final UserDetailsService userDetailsService;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        String username = String.valueOf(authentication.getPrincipal());
+        String password = String.valueOf(authentication.getCredentials());
+
+        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+        if (!passwordEncoder.matches(password, userDetails.getPassword())) {
+            throw new BadCredentialsException("아이디 또는 비밀번호가 올바르지 않습니다.");
+        }
+
+        return UsernamePasswordAuthenticationToken.authenticated(
+                userDetails,
+                null,
+                userDetails.getAuthorities()
+        );
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/src/main/java/com/todate/backend/auth/core/BasicUserDetailsService.java
+++ b/src/main/java/com/todate/backend/auth/core/BasicUserDetailsService.java
@@ -1,0 +1,30 @@
+package com.todate.backend.auth.core;
+
+import com.todate.backend.user.domain.User;
+import com.todate.backend.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BasicUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username).orElseThrow(() -> new UsernameNotFoundException("User not found"));
+
+        return org.springframework.security.core.userdetails.User.builder()
+                .username(user.getUsername())
+                .password(user.getPassword())
+                .authorities(Collections.emptyList())
+                .build();
+    }
+}

--- a/src/main/java/com/todate/backend/auth/dto/request/SignInRequest.java
+++ b/src/main/java/com/todate/backend/auth/dto/request/SignInRequest.java
@@ -1,5 +1,18 @@
 package com.todate.backend.auth.dto.request;
 
-public class SignInRequest {
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class SignInRequest {
+    @NotBlank(message = "아이디를 입력해주세요.")
+    private String userId;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
 }

--- a/src/main/java/com/todate/backend/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/todate/backend/auth/dto/request/SignUpRequest.java
@@ -1,5 +1,16 @@
 package com.todate.backend.auth.dto.request;
 
-public class SignUpRequest {
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
+@Getter
+public class SignUpRequest {
+    @NotBlank(message = "아이디를 입력해주세요.")
+    String userId;
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    String password;
+    @NotBlank(message = "이름을 입력해주세요.")
+    String name;
 }

--- a/src/main/java/com/todate/backend/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/todate/backend/auth/dto/request/SignUpRequest.java
@@ -1,16 +1,21 @@
 package com.todate.backend.auth.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 
-@RequiredArgsConstructor
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class SignUpRequest {
     @NotBlank(message = "아이디를 입력해주세요.")
-    String userId;
+    private String userId;
+
     @NotBlank(message = "비밀번호를 입력해주세요.")
-    String password;
+    private String password;
+
     @NotBlank(message = "이름을 입력해주세요.")
-    String name;
+    private String name;
 }

--- a/src/main/java/com/todate/backend/auth/dto/response/AccessTokenResponse.java
+++ b/src/main/java/com/todate/backend/auth/dto/response/AccessTokenResponse.java
@@ -1,0 +1,28 @@
+package com.todate.backend.auth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Duration;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AccessTokenResponse {
+    @JsonProperty("access_token")
+    private final String accessToken;
+
+    @JsonProperty("token_type")
+    private final String tokenType;
+
+    @JsonProperty("expires_in")
+    private final long expiresInSeconds;
+
+    public static AccessTokenResponse of(String accessToken, Duration ttl) {
+        long expiresIn = ttl != null ? ttl.toSeconds() : 0L;
+        return AccessTokenResponse.builder()
+                .accessToken(accessToken)
+                .tokenType("Bearer")
+                .expiresInSeconds(expiresIn)
+                .build();
+    }
+}

--- a/src/main/java/com/todate/backend/auth/dto/response/SignInResponse.java
+++ b/src/main/java/com/todate/backend/auth/dto/response/SignInResponse.java
@@ -1,5 +1,0 @@
-package com.todate.backend.auth.dto.response;
-
-public class SignInResponse {
-
-}

--- a/src/main/java/com/todate/backend/auth/dto/response/SignUpResponse.java
+++ b/src/main/java/com/todate/backend/auth/dto/response/SignUpResponse.java
@@ -1,5 +1,0 @@
-package com.todate.backend.auth.dto.response;
-
-public class SignUpResponse {
-
-}

--- a/src/main/java/com/todate/backend/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/todate/backend/auth/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,54 @@
+package com.todate.backend.auth.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        final String auth = request.getHeader("Authorization");
+        if (auth == null || !auth.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+
+
+        String token = auth.substring(7);
+        String username;
+        try {
+            username = jwtUtil.extractSubject(token);
+        } catch (Exception e) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            UserDetails user = userDetailsService.loadUserByUsername(username);
+            // 서명/만료는 jwtUtil.parse()에서 검증됨. 만료 체크까지.
+            if (!jwtUtil.isExpired(token) && username.equals(user.getUsername())) {
+                var authToken = new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
+                authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/todate/backend/auth/jwt/JwtProps.java
+++ b/src/main/java/com/todate/backend/auth/jwt/JwtProps.java
@@ -1,0 +1,12 @@
+package com.todate.backend.auth.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+@ConfigurationProperties(prefix = "spring.auth.jwt")
+public record JwtProps(
+        String secret,
+        Duration accessValid,
+        Duration refreshValid
+) {}

--- a/src/main/java/com/todate/backend/auth/jwt/JwtUtil.java
+++ b/src/main/java/com/todate/backend/auth/jwt/JwtUtil.java
@@ -1,0 +1,86 @@
+package com.todate.backend.auth.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+
+@Component
+public class JwtUtil {
+    private final SecretKey secretKey;
+    private final Duration accessTokenValidity;
+    private final Duration refreshTokenValidity;
+
+    public JwtUtil(JwtProps props) {
+        byte[] keyBytes;
+        try {
+            keyBytes = Decoders.BASE64.decode(props.secret());     // Base64 우선
+        } catch (IllegalArgumentException e) {
+            keyBytes = props.secret().getBytes(StandardCharsets.UTF_8); // 평문 fallback
+        }
+        if (keyBytes.length < 32) {
+            throw new IllegalStateException("JWT secret must be >= 32 bytes (256 bits).");
+        }
+        this.secretKey = Keys.hmacShaKeyFor(keyBytes);
+        this.accessTokenValidity = props.accessValid();
+        this.refreshTokenValidity = props.refreshValid();
+    }
+
+    public String generateAccessToken(String subject) {
+        return generateToken(subject, "access", accessTokenValidity);
+    }
+
+    public String generateRefreshToken(String subject) {
+        return generateToken(subject, "refresh", refreshTokenValidity);
+    }
+
+    public boolean isRefreshToken(String token) {
+        return "refresh".equals(parse(token).get("type"));
+    }
+
+    public String extractSubject(String token) {
+        return parse(token).getSubject();
+    }
+
+    public Date extractExpiration(String token) {
+        return parse(token).getExpiration();
+    }
+
+    public boolean isExpired(String token) {
+        return extractExpiration(token).before(new Date());
+    }
+
+    public Duration accessTokenTtl() {
+        return accessTokenValidity;
+    }
+
+    public Duration refreshTokenTtl() {
+        return refreshTokenValidity;
+    }
+
+    private String generateToken(String subject, String type, Duration ttl) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+                .subject(subject)
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plus(ttl)))
+                .claims(Map.of("type", type))
+                .signWith(secretKey, Jwts.SIG.HS256)
+                .compact();
+    }
+
+    private io.jsonwebtoken.Claims parse(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/main/java/com/todate/backend/auth/service/AuthService.java
+++ b/src/main/java/com/todate/backend/auth/service/AuthService.java
@@ -1,11 +1,18 @@
 package com.todate.backend.auth.service;
 
+import com.todate.backend.auth.dto.request.SignInRequest;
 import com.todate.backend.auth.dto.request.SignUpRequest;
+import com.todate.backend.auth.dto.response.AccessTokenResponse;
+import com.todate.backend.auth.jwt.JwtUtil;
 import com.todate.backend.user.domain.User;
 import com.todate.backend.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -16,15 +23,32 @@ import org.springframework.web.server.ResponseStatusException;
 public class AuthService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManager authenticationManager;
+    private final JwtUtil jwtUtil;
 
-    public void signupUser(SignUpRequest signUpRequest){
-        if (userRepository.existsUserByUserId(signUpRequest.getUserId())) {
+    public void signupUser(SignUpRequest signUpRequest) {
+        if (userRepository.existsUserByUsername(signUpRequest.getUserId())) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 가입된 회원입니다.");
         }
 
         String encoded = passwordEncoder.encode(signUpRequest.getPassword());
-
         User user = User.create(signUpRequest.getUserId(), encoded, signUpRequest.getName());
         userRepository.save(user);
+    }
+
+    public AccessTokenResponse login(SignInRequest signInRequest) {
+        Authentication authToken = UsernamePasswordAuthenticationToken.unauthenticated(
+                signInRequest.getUserId(),
+                signInRequest.getPassword()
+        );
+
+        try {
+            Authentication authenticated = authenticationManager.authenticate(authToken);
+            String username = authenticated.getName();
+            String accessToken = jwtUtil.generateAccessToken(username);
+            return AccessTokenResponse.of(accessToken, jwtUtil.accessTokenTtl());
+        } catch (AuthenticationException e) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 올바르지 않습니다.", e);
+        }
     }
 }

--- a/src/main/java/com/todate/backend/auth/service/AuthService.java
+++ b/src/main/java/com/todate/backend/auth/service/AuthService.java
@@ -6,6 +6,7 @@ import com.todate.backend.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -14,13 +15,16 @@ import org.springframework.web.server.ResponseStatusException;
 @Transactional
 public class AuthService {
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     public void signupUser(SignUpRequest signUpRequest){
         if (userRepository.existsUserByUserId(signUpRequest.getUserId())) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 가입된 회원입니다.");
         }
 
-        User user = User.create(signUpRequest.getUserId(), signUpRequest.getPassword(), signUpRequest.getName());
+        String encoded = passwordEncoder.encode(signUpRequest.getPassword());
+
+        User user = User.create(signUpRequest.getUserId(), encoded, signUpRequest.getName());
         userRepository.save(user);
     }
 }

--- a/src/main/java/com/todate/backend/auth/service/AuthService.java
+++ b/src/main/java/com/todate/backend/auth/service/AuthService.java
@@ -1,5 +1,26 @@
 package com.todate.backend.auth.service;
 
-public class AuthService {
+import com.todate.backend.auth.dto.request.SignUpRequest;
+import com.todate.backend.user.domain.User;
+import com.todate.backend.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthService {
+    private final UserRepository userRepository;
+
+    public void signupUser(SignUpRequest signUpRequest){
+        if (userRepository.existsUserByUserId(signUpRequest.getUserId())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 가입된 회원입니다.");
+        }
+
+        User user = User.create(signUpRequest.getUserId(), signUpRequest.getPassword(), signUpRequest.getName());
+        userRepository.save(user);
+    }
 }

--- a/src/main/java/com/todate/backend/user/domain/User.java
+++ b/src/main/java/com/todate/backend/user/domain/User.java
@@ -2,23 +2,26 @@ package com.todate.backend.user.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
 @Getter @Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class User {
     
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private String user_id;
+    private String userId;
 
     @Column(nullable = false)
     private String password;
     
     @Column(nullable = false)
     private String name;
+
+    public static User create(String userId, String encodedPassword, String name) {
+        return User.builder().userId(userId).password(encodedPassword).name(name).build();
+    }
 }

--- a/src/main/java/com/todate/backend/user/domain/User.java
+++ b/src/main/java/com/todate/backend/user/domain/User.java
@@ -3,17 +3,24 @@ package com.todate.backend.user.domain;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.*;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
 
 @Entity
-@Getter @Setter
+@Table(name = "users")
+@Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class User {
-    
+public class User implements UserDetails{
     @Id
-    private String userId;
+    private String username;
 
     @Column(nullable = false)
     private String password;
@@ -22,6 +29,11 @@ public class User {
     private String name;
 
     public static User create(String userId, String encodedPassword, String name) {
-        return User.builder().userId(userId).password(encodedPassword).name(name).build();
+        return User.builder().username(userId).password(encodedPassword).name(name).build();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
     }
 }

--- a/src/main/java/com/todate/backend/user/repository/UserRepository.java
+++ b/src/main/java/com/todate/backend/user/repository/UserRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.todate.backend.user.domain.User;
 
 public interface UserRepository extends JpaRepository<User, String>{
-
+    Boolean existsUserByUserId(String userId);
 }

--- a/src/main/java/com/todate/backend/user/repository/UserRepository.java
+++ b/src/main/java/com/todate/backend/user/repository/UserRepository.java
@@ -4,6 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.todate.backend.user.domain.User;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, String>{
-    Boolean existsUserByUserId(String userId);
+    Boolean existsUserByUsername(String username);
+    Optional<User> findByUsername(String username);
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -19,6 +19,11 @@ spring:
     console:
       enabled: true
       path: /h2-console
+  auth:
+    jwt:
+      secret: coolscretcoolscretcoolscretcoolscretcoolscret
+      access-valid: 1d
+      refresh-valid: 1d
 logging:
   level:
     org.hibernate.sql: debug

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,24 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+  datasource:
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+    url: jdbc:h2:file:./.local/h2/devdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.H2Dialect
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+logging:
+  level:
+    org.hibernate.sql: debug

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=backend

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,5 @@
+spring:
+  application:
+    name: backend
+  profiles:
+    default: local


### PR DESCRIPTION
작성자: @github_nickname

#3

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 작업 내역

- Auth관련 기본 기능 구현
- JwtAuthFilter 이용하여 AuthConfig에 지정된 path 이외에 jwt로 인가 검증
- BasicAuthenticationProvider를 통해 로컬 로그인 제공

## 비고

- refresh토큰 구현 필요
- 현재는 AT의 기한을 1일으로 설정하였습니다.