### PR TITLE
FEAT#30 ios, android 로그인 대응

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,8 @@ JWT_SECRET=your-super-secret-jwt-key-for-local-dev-32bytes
 JWT_ACCESS_VALIDITY=1d
 JWT_REFRESH_VALIDITY=7d
 
-# Google OAuth
-GOOGLE_CLIENT_ID=your-google-client-id
+# Google OAuth (콤마로 구분, Android/iOS Client ID)
+GOOGLE_CLIENT_IDS=your-android-client-id.apps.googleusercontent.com,your-ios-client-id.apps.googleusercontent.com
 
 # Redis
 REDIS_HOST=redis

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,7 +80,7 @@ jobs:
           JWT_REFRESH_VALIDITY=${{ secrets.JWT_REFRESH_VALIDITY }}
           
           # Google OAuth
-          GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_IDS=${{ secrets.GOOGLE_CLIENT_IDS }}
           
           # Redis
           REDIS_HOST=redis

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,13 +72,18 @@ DTOs: Separate request/response packages per domain
 The codebase is organized into four main domains under `com.todate.backend`:
 
 **1. Auth Domain** (`auth/`)
-- JWT-based authentication system
+- JWT-based authentication system with Google OAuth2 support
 - Key classes:
   - `JwtUtil`: Token generation/validation
   - `JwtAuthenticationFilter`: Request filter for JWT validation
   - `SecurityConfig`: Security filter chain configuration
   - `AuthService`: Login/signup logic
-- Endpoints: `/auth/register`, `/auth/login` (no authentication required)
+  - `GoogleTokenVerifier`: Google ID Token verification (supports multiple Client IDs for Android/iOS)
+  - `GoogleOAuth2Props`: Configuration for Google OAuth Client IDs
+- Authentication methods:
+  - Google OAuth2: ID Token verification with multi-platform support (Android/iOS)
+  - Auto-registration on first Google login
+- Endpoints: `/auth/google/login` (no authentication required)
 
 **2. User Domain** (`user/`)
 - User management and couple relationships
@@ -146,6 +151,7 @@ Required in `.env` file or environment:
 - `JWT_SECRET`: JWT signing key (must be >=32 bytes)
 - `JWT_ACCESS_VALIDITY`: Access token duration (e.g., "1d")
 - `JWT_REFRESH_VALIDITY`: Refresh token duration (e.g., "1d")
+- `GOOGLE_CLIENT_IDS`: Comma-separated Google OAuth Client IDs for Android/iOS (e.g., "android-id,ios-id")
 - `MAIL_ID`: Email service ID (future use)
 - `MAIL_PASSWORD`: Email service password (future use)
 

--- a/src/main/java/com/todate/backend/auth/config/GoogleOAuth2Props.java
+++ b/src/main/java/com/todate/backend/auth/config/GoogleOAuth2Props.java
@@ -2,16 +2,20 @@ package com.todate.backend.auth.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.List;
+
 /**
  * Google OAuth2 설정을 yml에서 주입받는 클래스
  *
  * application.yml:
  * google:
  *   oauth2:
- *     client-id: your-client-id.apps.googleusercontent.com
+ *     client-ids: android-id,ios-id
+ *
+ * 여러 플랫폼(Android, iOS)의 Client ID를 리스트로 관리
  */
 @ConfigurationProperties(prefix = "google.oauth2")
 public record GoogleOAuth2Props(
-    String clientId
+    List<String> clientIds
 ) {
 }

--- a/src/main/java/com/todate/backend/auth/jwt/GoogleTokenVerifier.java
+++ b/src/main/java/com/todate/backend/auth/jwt/GoogleTokenVerifier.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
-import java.util.Collections;
 
 /**
  * Google ID Token 검증 클래스
@@ -33,8 +32,8 @@ public class GoogleTokenVerifier {
             new NetHttpTransport(),
             new GsonFactory()
         )
-        // aud (Audience) 검증: 우리 앱의 Client ID인지 확인
-        .setAudience(Collections.singletonList(props.clientId()))
+        // aud (Audience) 검증: Android/iOS 등 여러 플랫폼의 Client ID 중 하나와 일치하는지 확인
+        .setAudience(props.clientIds())
         // iss (Issuer) 검증: Google이 발급했는지 확인 (자동)
         .build();
     }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,7 +22,7 @@ spring:
       refresh-valid: ${JWT_REFRESH_VALIDITY}
 google:
   oauth2:
-    client-id: ${GOOGLE_CLIENT_ID}
+    client-ids: ${GOOGLE_CLIENT_IDS}
 server:
   error:
     include-stacktrace: never

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -36,7 +36,7 @@ spring:
 
 google:
   oauth2:
-    client-id: ${GOOGLE_CLIENT_ID}
+    client-ids: ${GOOGLE_CLIENT_IDS}
 
 kakao:
   api:


### PR DESCRIPTION
작성자: @parkjin21004 

Closes #30

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 상단에 이슈 번호를 기입했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Reviewers/Assignees/Labels을 알맞게 설정했나요?

## 작업 내역

 - GoogleOAuth2Props를 단일 clientId에서 List<String> clientIds로 변경
  - GoogleTokenVerifier에서 여러 플랫폼의 Client ID 동시 검증 지원
  - 환경변수 GOOGLE_CLIENT_ID를 GOOGLE_CLIENT_IDS로 변경 (콤마 구분)
  - Android, iOS 각각의 OAuth Client ID로 로그인 가능

BREAKING CHANGE:
  환경변수 이름이 GOOGLE_CLIENT_ID에서 GOOGLE_CLIENT_IDS로 변경되었습니다.
  배포 시 GitHub Secrets 업데이트 필요:
  - 기존: GOOGLE_CLIENT_ID=single-id
  - 신규: GOOGLE_CLIENT_IDS=android-id,ios-id

## 비고

- env 요청주세용